### PR TITLE
appbar: null animator targets in onAnimationEnd to prevent memory leaks

### DIFF
--- a/lib/java/com/google/android/material/appbar/StackViewGroup.kt
+++ b/lib/java/com/google/android/material/appbar/StackViewGroup.kt
@@ -62,6 +62,7 @@ class StackViewGroup(val rootView: FrameLayout) {
             addListener(object : Animator.AnimatorListener {
                 override fun onAnimationEnd(animation: Animator) {
                     (target as? View)?.let { rootView.removeView(it) }
+                    target = null // prevent leaked strong ref to detached SuggestAppBarView
                 }
 
                 override fun onAnimationStart(animation: Animator) {}

--- a/lib/java/com/google/android/material/appbar/StackViewGroup.kt
+++ b/lib/java/com/google/android/material/appbar/StackViewGroup.kt
@@ -50,7 +50,9 @@ class StackViewGroup(val rootView: FrameLayout) {
                     (target as? View)?.visibility = View.VISIBLE
                 }
 
-                override fun onAnimationEnd(animation: Animator) {}
+                override fun onAnimationEnd(animation: Animator) {
+                    target = null // prevent leaked strong ref after animation completes
+                }
                 override fun onAnimationCancel(animation: Animator) {}
                 override fun onAnimationRepeat(animation: Animator) {}
             })


### PR DESCRIPTION
## Summary

- `hideAnimator.onAnimationEnd`: set `target = null` after removing the view from the root — prevents `ObjectAnimator.mTarget` from retaining the detached `SuggestAppBarView` after hide animation completes
- `showAnimator.onAnimationEnd`: same fix — `mTarget` holds a strong ref after show animation ends with no cleanup

## Test plan
- [ ] Show and hide the suggest app bar repeatedly and verify LeakCanary reports no `SuggestAppBarView`-related leaks
- [ ] Confirm show/hide animations are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)